### PR TITLE
Fix office hours calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ in `_config.yml`
 
 The navigation is set by the values in `_data/navigation.yml`
 
-Jekyll status on Travis-CI: [![Build Status](https://travis-ci.org/ucsb-cs48/w20.svg?branch=master)](https://travis-ci.org/ucsb-cs48/s20)
+Jekyll status on Travis-CI: [![Build Status](https://travis-ci.org/ucsb-cs48/s20.svg?branch=master)](https://travis-ci.org/ucsb-cs48/s20)
 
 * Travis-ci: https://travis-ci.org/ucsb-cs48/s20
 * To add a status image like this in your README.md, see [these instructions](https://docs.travis-ci.com/user/status-images/)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ in `_config.yml`
 
 The navigation is set by the values in `_data/navigation.yml`
 
-Jekyll status on Travis-CI: [![Build Status](https://travis-ci.org/ucsb-cs48/w20.svg?branch=master)](https://travis-ci.org/ucsb-cs48/w20)
+Jekyll status on Travis-CI: [![Build Status](https://travis-ci.org/ucsb-cs48/w20.svg?branch=master)](https://travis-ci.org/ucsb-cs48/s20)
 
-* Travis-ci: https://travis-ci.org/ucsb-cs48/w20
+* Travis-ci: https://travis-ci.org/ucsb-cs48/s20
 * To add a status image like this in your README.md, see [these instructions](https://docs.travis-ci.com/user/status-images/)
 
 To test locally:
@@ -22,7 +22,7 @@ To test locally:
     * Install rvm (the Ruby version manager)
     * Run `./setup.sh` to install correct ruby version, bundler version, and bundle the gems
 * From then on, to test the site locally:
-    * Run `./jekyll.sh
-    * Point browser to <http://localhost:4000/w20/>
+    * Run `./jekyll.sh`
+    * Point browser to <http://localhost:4000/s20/>
 
 

--- a/_info/office_hours.md
+++ b/_info/office_hours.md
@@ -4,5 +4,4 @@ layout: default
 ready: true
 ---
 
-
-
+<iframe src="https://calendar.google.com/calendar/embed?src=ucsb.edu_s2rctkp39odqsohomovpau2qfs%40group.calendar.google.com&ctz=America%2FLos_Angeles" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
This PR adds the office hours google calendar to the s20/info/office_hours/ page (previously missing).

Also updated a few lines on readme that pointed to w20 instead of s20